### PR TITLE
Fixed file addition after deleting all the files

### DIFF
--- a/02-data/starting-points/aggr-redux/src/reducers/fileReducer.js
+++ b/02-data/starting-points/aggr-redux/src/reducers/fileReducer.js
@@ -27,7 +27,7 @@ export default function fileReducer(state = {}, action) {
 
 const newFile = existingFiles => {
   const num = getNextUntitledFileNumber(existingFiles);
-  let lastId = existingFiles[existingFiles.length - 1].id;
+  let lastId = existingFiles[existingFiles.length - 1]?.id || 0;
   return {
     id: lastId + 1,
     file: `untitled${num > 0 ? num : ""}.txt`,


### PR DESCRIPTION
Bug fix : 

Select all the files and delete. After deletion try to add a new file. Upon adding new file it throws error.

Handled the above issue.